### PR TITLE
Update metrics.py

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -21,10 +21,13 @@ def ssim(clean, noisy, normalized=True, raw=False):
     if raw:
         noisy = (np.uint16(noisy*(2**12-1-240)+240).astype(np.float32)-240)/(2**12-1-240)
     
-    if normalized:
-        return np.array([structural_similarity(c, n, data_range=255, multichannel=True) for c, n in zip(clean, noisy)]).mean()
+    ax=clean.shape[3]-1
+    
+    if  not normalized:
+        return np.array([structural_similarity(c, n, data_range=255, multichannel=True,channel_axis=ax) for c, n in zip(clean, noisy)]).mean()
     else:
-        return np.array([structural_similarity(c, n, data_range=1.0, multichannel=True) for c, n in zip(clean, noisy)]).mean()
+        return np.array([structural_similarity(c, n, data_range=1.0, multichannel=True,channel_axis=ax) for c, n in zip(clean, noisy)]).mean()
+
 
 
 def psnr(clean, noisy, normalized=True, raw=False):
@@ -47,7 +50,7 @@ def psnr(clean, noisy, normalized=True, raw=False):
     if raw:
         noisy = (np.uint16(noisy*(2**12-1-240)+240).astype(np.float32)-240)/(2**12-1-240)
     
-    if normalized:
+    if not normalized:
         return np.array([peak_signal_noise_ratio(c, n, data_range=255) for c, n in zip(clean, noisy)]).mean()
     else:
         return np.array([peak_signal_noise_ratio(c, n, data_range=1.0) for c, n in zip(clean, noisy)]).mean()


### PR DESCRIPTION
In the updated version of the structural similarity function channel axis is explicitly mentioned to avoid the value error of getting an image size smaller than the window size. And data range values were also the opposite.